### PR TITLE
Alt gr send string

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,1 @@
+04-12-2019 - Add AltGr/RALT support to Send String #4046

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -851,6 +851,26 @@ const bool ascii_to_shift_lut[0x80] PROGMEM = {
 };
 
 __attribute__ ((weak))
+const bool ascii_to_altgr_lut[0x80] PROGMEM = {
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0
+};
+
+__attribute__ ((weak))
 const uint8_t ascii_to_keycode_lut[0x80] PROGMEM = {
     0, 0, 0, 0, 0, 0, 0, 0,
     KC_BSPC, KC_TAB, KC_ENT, 0, 0, 0, 0, 0,
@@ -931,16 +951,22 @@ void send_string_with_delay_P(const char *str, uint8_t interval) {
 }
 
 void send_char(char ascii_code) {
-  uint8_t keycode;
-  keycode = pgm_read_byte(&ascii_to_keycode_lut[(uint8_t)ascii_code]);
-  if (pgm_read_byte(&ascii_to_shift_lut[(uint8_t)ascii_code])) {
-      register_code(KC_LSFT);
-      register_code(keycode);
-      unregister_code(keycode);
-      unregister_code(KC_LSFT);
-  } else {
-      register_code(keycode);
-      unregister_code(keycode);
+  uint8_t keycode = pgm_read_byte(&ascii_to_keycode_lut[(uint8_t)ascii_code]);
+  bool is_shifted = pgm_read_byte(&ascii_to_shift_lut[(uint8_t)ascii_code]);
+  bool is_altgred = pgm_read_byte(&ascii_to_altgr_lut[(uint8_t)ascii_code]);
+
+  if (is_shifted) {
+    register_code(KC_LSFT);
+  }
+  if (is_altgred) {
+    register_code(KC_RALT);
+  }
+  tap_code(keycode);
+  if (is_altgred) {
+    unregister_code(KC_RALT);
+  }
+  if (is_shifted) {
+    unregister_code(KC_LSFT);
   }
 }
 

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -206,6 +206,7 @@ extern uint32_t default_layer_state;
 
 #define SEND_STRING(str) send_string_P(PSTR(str))
 extern const bool ascii_to_shift_lut[0x80];
+extern const bool ascii_to_altgr_lut[0x80];
 extern const uint8_t ascii_to_keycode_lut[0x80];
 void send_string(const char *str);
 void send_string_with_delay(const char *str, uint8_t interval);


### PR DESCRIPTION
I'm not sure if we'll actually need this, but ... just in case we add support for it later, here it is. 


Adds a table for AltGR'ed keycodes in SEND_STRING