### PR TITLE
Fix Ergodox EZ keyboard dimensions in info.json

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,2 +1,3 @@
-04-12-2019 - Add AltGr/RALT support to Send String #4046
-04-12-2019 - Port DIRECT_PINS from split_common/matrix.c to matrix.c (qmk#5091)
+04-12-2019 - Add AltGr/RALT support to Send String #4046  
+04-12-2019 - Port DIRECT_PINS from split_common/matrix.c to matrix.c (qmk#5091)  
+04-16-2019 - Fix info.json for Ergodox EZ  

--- a/keyboards/ergodox_ez/info.json
+++ b/keyboards/ergodox_ez/info.json
@@ -2,8 +2,8 @@
     "keyboard_name": "ErgoDox EZ",
     "url": "ergodox-ez.com",
     "maintainer": "erez",
-    "width": 19.5,
-    "height": 9.375,
+    "width": 17,
+    "height": 8,
 
     "layouts": {
         "LAYOUT_ergodox": {


### PR DESCRIPTION
I'm not sure if we use this, but it may be a good idea to keep this in sync. 