### PR TITLE
Only increment Enable status for RGB Matrix if it supports it

### DIFF
--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -511,7 +511,11 @@ void rgb_matrix_set_suspend_state(bool state) {
 }
 
 void rgb_matrix_toggle(void) {
+#ifdef RGB_MATRIX_EXTRA_TOG
   rgb_matrix_config.enable++;
+#else
+  rgb_matrix_config.enable ^= 1;
+#endif
   if (!rgb_matrix_config.enable) {
     rgb_task_state = STARTING;
   }

--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -515,6 +515,7 @@ void rgb_matrix_toggle(void) {
   rgb_matrix_config.enable++;
 #else
   rgb_matrix_config.enable ^= 1;
+  if (rgb_matrix_config.enable > 1) { rgb_matrix_config.enable = 0; } // make sure that if we are treating this as a bool, that it is only 1 or 0.
 #endif
   if (!rgb_matrix_config.enable) {
     rgb_task_state = STARTING;


### PR DESCRIPTION
Aka, fix the RGB_TOG code.

We could just use the call in the "else" section, but I'd rather keep this in parity with what the upstream is using, to prevent merge conflicts. 